### PR TITLE
fixed wrong cache invalidation

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,3 +1,5 @@
+---
+
 version: 0.2
 
 env:
@@ -24,5 +26,5 @@ phases:
     commands:
       - aws s3 cp --recursive ./dist s3://js30.metax7.my-best-code.com/
       - aws s3 cp --metadata-directive REPLACE --cache-control="max-age=60, s-maxage=86400" ./dist/index.html s3://js30.metax7.my-best-code.com/
-      - aws cloudfront create-invalidation --distribution-id $CF_DISTR_ID --paths /*
+      - aws cloudfront create-invalidation --distribution-id $CF_DISTR_ID --paths '/*'
   


### PR DESCRIPTION
Due to passing /* as argument instead of '/*' not all objects in cache were invalidated but those under path presenting in the working directory of pipeline job. 